### PR TITLE
Add new function to BaseSerializer: if the serailizer can't flatten t…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.util import convert_path
 from fnmatch import fnmatchcase
 from setuptools import setup, find_packages
 
-version = '0.22'
+version = '0.23'
 
 # Provided as an attribute, so you can append to these instead
 # of replicating them:

--- a/tests/paginator.py
+++ b/tests/paginator.py
@@ -1,0 +1,6 @@
+from django.core.paginator import Paginator
+
+
+objects = ['john', 'paul', 'george', 'ringo']
+p = Paginator(objects, 2)
+page = p.page(2)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,14 +1,35 @@
-import json
-
-from restify.serializers import ModelSerializer
+import datetime
+import random
 
 from django import forms
 from django.test import TestCase
+
+from .paginator import page
+from restify.serializers import ModelSerializer, DjangoSerializer
 
 
 class Frm(forms.Form):
     first = forms.CharField()
     second = forms.ChoiceField(choices=[(1, 1), (2, 2)])
+
+
+class Structure(object):
+    value1 = random.randint(1, 100)
+    value2 = datetime.datetime.now()
+    value3 = Frm({'first': 'example', 'second': 1})
+
+    def flatten(self):
+        retval = {
+            'value1': self.value1,
+            'value2': self.value2.strftime('%Y-%m-%d %H:%M')
+        }
+        if self.value3.is_valid():
+            retval['frm'] = {
+                'first': self.value3.cleaned_data['first'],
+                'second': self.value3.cleaned_data['second']
+            }
+
+        return retval
 
 
 class BaseSerializerTest(TestCase):
@@ -20,3 +41,27 @@ class BaseSerializerTest(TestCase):
         simple = self.serializer.flatten(form)
         self.assertIsInstance(simple, {}.__class__)
         self.assertEqual(set(simple.keys()), set(['first', 'second']))
+
+    def test_serialize_with_flatten(self):
+        obj = Structure()
+        simple = self.serializer.flatten(obj)
+
+        self.assertSequenceEqual(simple, obj.flatten())
+
+
+################################# DjangoSearializer
+
+class DjangoSerializerTest(TestCase):
+    def setUp(self):
+        self.serializer = DjangoSerializer()
+
+    def test_paginator_serializer(self):
+        serialized = {
+            "current": page.number,
+            "list": [{'key': 1, 'value': 1}, {'key': 2, 'value': 2}, None], # previous, current, next (if we have)
+            "num_pages": page.paginator.num_pages
+        }
+
+        simple = self.serializer.flatten(page)
+
+        self.assertEqual(simple, serialized)


### PR DESCRIPTION
…he object, but the object can herself (has flatten method), then call obj.flatten()

Add new serailizer class: DjangoSerializer. This is for the django specific object serializing (eg. Page object). The ModelSerializer is inherited from
this class.
